### PR TITLE
fixed segfault when parsing clli and mdcv boxes

### DIFF
--- a/codecs/description.c
+++ b/codecs/description.c
@@ -283,8 +283,16 @@ static int isom_initialize_structured_codec_specific_data( lsmash_codec_specific
             specific->size     = sizeof(lsmash_qt_audio_channel_layout_t);
             specific->destruct = lsmash_free;
             break;
-        case LSMASH_CODEC_SPECIFIC_DATA_TYPE_ISOM_RTP_HINT_COMMON:
+        case LSMASH_CODEC_SPECIFIC_DATA_TYPE_ISOM_RTP_HINT_COMMON :
             specific->size     = sizeof(lsmash_isom_rtp_reception_hint_t);
+            specific->destruct = lsmash_free;
+            break;
+        case LSMASH_CODEC_SPECIFIC_DATA_TYPE_QT_VIDEO_CONTENT_LIGHT_LEVEL_INFO :
+            specific->size     = sizeof(lsmash_qt_content_light_level_info_t);
+            specific->destruct = lsmash_free;
+            break;
+        case LSMASH_CODEC_SPECIFIC_DATA_TYPE_QT_VIDEO_MASTERING_DISPLAY_COLOR_VOLUME :
+            specific->size     = sizeof(lsmash_qt_mastering_display_color_volume_t);
             specific->destruct = lsmash_free;
             break;
         default :


### PR DESCRIPTION
Both of these need the creation codec specific data structs, but would fall through to the default case in the switch that does the allocation, creating nothing.  This would result in a segmentation fault when the data would be put into the codec specific struct, as it was set to NULL.  Fix is to set the size of data needed to the size of the codec specific data structs that are needed.